### PR TITLE
Update yargs version from 11.0.0 to 18.1.2

### DIFF
--- a/package.json
+++ b/package.json
@@ -34,7 +34,7 @@
     "js-beautify": "^1.7.5",
     "named-js-regexp": "^1.3.3",
     "yamljs": "^0.3.0",
-    "yargs": "^18.1.2"
+    "yargs": "17.3.1"
   },
   "devDependencies": {
     "babel-core": "^6.26.0",

--- a/package.json
+++ b/package.json
@@ -34,7 +34,7 @@
     "js-beautify": "^1.7.5",
     "named-js-regexp": "^1.3.3",
     "yamljs": "^0.3.0",
-    "yargs": "^11.0.0"
+    "yargs": "^18.1.2"
   },
   "devDependencies": {
     "babel-core": "^6.26.0",


### PR DESCRIPTION
This is to fix Prototype Pollution Vulnerability in yargs-parser.